### PR TITLE
fix: callback_handler를 동기 처리로 변경

### DIFF
--- a/callback.py
+++ b/callback.py
@@ -1,6 +1,6 @@
 from dto import ChatbotRequest
 from samples import list_card
-import aiohttp
+import requests
 import time
 import logging
 import openai
@@ -10,7 +10,7 @@ openai.api_key = ''
 SYSTEM_MSG = "당신은 카카오 서비스 제공자입니다."
 logger = logging.getLogger("Callback")
 
-async def callback_handler(request: ChatbotRequest) -> dict:
+def callback_handler(request: ChatbotRequest) -> dict:
 
     # ===================== start =================================
     response = openai.ChatCompletion.create(
@@ -41,11 +41,7 @@ async def callback_handler(request: ChatbotRequest) -> dict:
     # 참고링크1 : https://kakaobusiness.gitbook.io/main/tool/chatbot/skill_guide/ai_chatbot_callback_guide
     # 참고링크1 : https://kakaobusiness.gitbook.io/main/tool/chatbot/skill_guide/answer_json_format
 
-    time.sleep(1.0)
-
     url = request.userRequest.callbackUrl
 
     if url:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url=url, json=payload, ssl=False) as resp:
-                await resp.json()
+        requests.post(url, json=payload)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi==0.100.0
 uvicorn==0.22.0
 gunicorn==20.1.0
-aiohttp==3.8.5
 openai==0.28


### PR DESCRIPTION
## Issue
Request가 background_tasks.add_task 동작이 끝날때까지 멈추지 않는 현상
-> AI model 응답이 5초 초과될 경우 응답이 오질 않습니다.

## Resolved
https://github.com/tiangolo/fastapi/issues/1313
> 요약: fast api의 background_tasks.add_task은 async 함수를 돌릴 때 await가 없는 IO 요청만 있어야 한다. 혹은 아예 동기 함수를 사용해야한다.

-> 기본 requests 패키지를 사용하도록 코드 변경, 불필요한 aiohttp 제거

## 기타
callback 메시지를 사용하고 싶다면 callback 설정을 아래와 같이해줘야 합니다.
![image](https://github.com/kakao-aicoursework/kakaochattest_guide/assets/39543643/e50fd0d3-1e7a-456b-a9b2-c89f941e8f74)

